### PR TITLE
Add navigation landmarks for a11y tool users

### DIFF
--- a/src/lib/Footer.svelte
+++ b/src/lib/Footer.svelte
@@ -1,11 +1,24 @@
-<div class="footer primary-bg">
-	<a href="https://twitter.com/dddsouthwest" target="_blank">
-		<i class="fa-brands fa-twitter fa-3x" title="DDD South West Twitter" />
-	</a>
-	<a href="https://www.linkedin.com/company/ddd-south-west/" target="_blank">
-		<i class="fa-brands fa-linkedin fa-3x" title="DDD South West LinkedIn" />
-	</a>
-</div>
+<script lang="ts">
+	export let isHomepage: boolean;
+</script>
+
+<footer class="container">
+	{#if !isHomepage}
+		<div class="quaternary-bg">
+			<div class="text-center">
+				<h2>By the community, for the community</h2>
+			</div>
+		</div>
+	{/if}
+	<div class="footer primary-bg">
+		<a href="https://twitter.com/dddsouthwest" target="_blank">
+			<i class="fa-brands fa-twitter fa-3x" title="DDD South West Twitter" />
+		</a>
+		<a href="https://www.linkedin.com/company/ddd-south-west/" target="_blank">
+			<i class="fa-brands fa-linkedin fa-3x" title="DDD South West LinkedIn" />
+		</a>
+	</div>
+</footer>
 
 <style>
 	.footer {
@@ -21,5 +34,9 @@
 
 	.fa-brands:hover {
 		color: white;
+	}
+
+	h2 {
+		padding: 0 10px;
 	}
 </style>

--- a/src/lib/Header.svelte
+++ b/src/lib/Header.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import Navbar from '$lib/Navbar.svelte';
+	import Carousel from '$lib/Carousel.svelte';
+	import { pageTitle, navExpanded } from '../stores.js';
+
+	function toggleNav() {
+		if ($navExpanded === true) {
+			$navExpanded = !$navExpanded;
+		}
+	}
+
+	export let isHomepage: boolean;
+</script>
+
+<header>
+	{#if isHomepage}
+		<Carousel>
+			<Navbar />
+		</Carousel>
+	{:else}
+		<div class="gradient-bg">
+			<div class="header">
+				<a href="/" class="logo-link" on:click={toggleNav}>
+					<img src="../images/logo.png" alt="The DDD South West logo" class="logo" />
+				</a>
+				<h1>{$pageTitle}</h1>
+				<Navbar />
+			</div>
+		</div>
+	{/if}
+</header>
+
+<style>
+	.gradient-bg {
+		background: rgb(255, 153, 48);
+		background: linear-gradient(
+			90deg,
+			rgba(255, 153, 48, 1) 0%,
+			rgba(255, 193, 48, 1) 50%,
+			rgba(150, 198, 202, 1) 100%
+		);
+	}
+
+	.header {
+		display: flex;
+		align-items: center;
+	}
+
+	.logo {
+		padding: 10px;
+	}
+
+	.logo-link {
+		display: none;
+	}
+
+	h1 {
+		padding-left: 20px;
+	}
+
+	@media (min-width: 576px) {
+		.header {
+			justify-content: space-between;
+			flex-direction: row;
+			text-align: left;
+		}
+	}
+
+	@media (min-width: 768px) {
+		.logo {
+			max-width: 150px;
+			padding: 30px;
+		}
+
+		.logo-link {
+			display: inline;
+		}
+	}
+
+	@media (min-width: 992px) {
+		.logo {
+			max-width: 300px;
+		}
+
+		h1 {
+			font-size: 2.5rem;
+		}
+	}
+</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,106 +1,20 @@
 <script lang="ts">
+	import Header from '$lib/Header.svelte';
 	import Footer from '$lib/Footer.svelte';
-	import Navbar from '$lib/Navbar.svelte';
 	import { page } from '$app/stores';
-	import { pageTitle, navExpanded } from '../stores.js';
+	import { pageTitle } from '../stores.js';
 
-	function toggleNav() {
-		if ($navExpanded === true) {
-			$navExpanded = !$navExpanded;
-		}
-	}
-
-	$: homepage = $page.url.pathname === '/';
+	$: isHomepage = $page.url.pathname === '/';
 </script>
 
 <svelte:head>
 	<title>{$pageTitle}</title>
 </svelte:head>
 
-<div class="container">
-	{#if !homepage}
-		<div class="gradient-bg">
-			<div class="header">
-				<a href="/" class="logo-link" on:click={toggleNav}>
-					<img src="../images/logo.png" alt="The DDD South West logo" class="logo" />
-				</a>
-				<h1>{$pageTitle}</h1>
-				<Navbar />
-			</div>
-		</div>
-	{/if}
+<Header {isHomepage} />
 
+<main class="container">
 	<slot />
+</main>
 
-	{#if !homepage}
-		<div class="quaternary-bg">
-			<div class="text-center">
-				<h2>By the community, for the community</h2>
-			</div>
-		</div>
-	{/if}
-
-	<Footer />
-</div>
-
-<style>
-	.gradient-bg {
-		background: rgb(255, 153, 48);
-		background: linear-gradient(
-			90deg,
-			rgba(255, 153, 48, 1) 0%,
-			rgba(255, 193, 48, 1) 50%,
-			rgba(150, 198, 202, 1) 100%
-		);
-	}
-
-	.header {
-		display: flex;
-		align-items: center;
-	}
-
-	.logo {
-		padding: 10px;
-	}
-
-	.logo-link {
-		display: none;
-	}
-
-	h1 {
-		padding-left: 20px;
-	}
-
-	h2 {
-		padding: 0 10px;
-	}
-
-	@media (min-width: 576px) {
-		.header {
-			justify-content: space-between;
-			flex-direction: row;
-			text-align: left;
-		}
-	}
-
-	@media (min-width: 768px) {
-		.logo {
-			max-width: 150px;
-			padding: 30px;
-		}
-
-		.logo-link {
-			display: inline;
-		}
-	}
-
-	@media (min-width: 992px) {
-		.logo {
-			max-width: 300px;
-		}
-
-		h1 {
-			font-size: 2.5rem;
-		}
-	}
-</style>
+<Footer {isHomepage} />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
 	import CallToActions from '$lib/CallToActions.svelte';
-	import Carousel from '$lib/Carousel.svelte';
-	import Navbar from '$lib/Navbar.svelte';
 	import Sponsors from '$lib/Sponsors.svelte';
 	import type { KeyPoint } from '../types/KeyPoint.type';
 
@@ -30,10 +28,6 @@
 		}
 	];
 </script>
-
-<Carousel>
-	<Navbar />
-</Carousel>
 
 <div class="introduction primary-bg">
 	<div class="section">

--- a/static/global.css
+++ b/static/global.css
@@ -22,7 +22,6 @@ html {
 .container {
 	display: flex;
 	flex-direction: column;
-	height: 100%;
 }
 
 .section {


### PR DESCRIPTION
## Changes

* Added `<header>`, `<main>` and `<footer>` tags which provide essential landmarks on the page for a11y software to use.
* Abstracted all header components to a header component (so it can be easily encompassed by the `<header>` tag)
* Moved all footer components to the footer component (so it can be easily encompassed by the `<footer>` tag)
* Put the `container` css class on each of the new tags, changed it slightly and removed surrounding div to fix a css issue

Using the [Accessibility Insights for Web](https://accessibilityinsights.io/) extension, here is a visualisation of the changes 

### Before

![image](https://github.com/dddsw/dddsw-web/assets/9001998/1c45ede0-c1e4-4446-b3fe-c2bbbf19a2cd)

### After

![image](https://github.com/dddsw/dddsw-web/assets/9001998/d272c243-1e28-4211-ba2e-66a3e56c4171)
