### PR TITLE
Use section rather than sponsors css

### DIFF
--- a/src/lib/Sponsors.svelte
+++ b/src/lib/Sponsors.svelte
@@ -84,7 +84,7 @@
 	}
 </script>
 
-<div class="sponsors">
+<div class="section">
 	<h2>With thanks to our confirmed 2025 sponsors:</h2>
 	<div class="sponsor-logos">
 		{#each sponsors as sponsor}
@@ -98,12 +98,6 @@
 </div>
 
 <style>
-	.sponsors {
-		width: 70%;
-		margin: auto;
-		padding-bottom: 30px;
-	}
-
 	.sponsor-logos {
 		display: flex;
 		justify-content: space-evenly;


### PR DESCRIPTION
This fixes the overflow issue on large screens

Before:
![image](https://github.com/user-attachments/assets/1acc9076-97d7-423d-b0fa-3eb35d7a68d2)


After:
![image](https://github.com/user-attachments/assets/5f292cc5-5e99-41a5-a01f-1569e09f9ad9)
