### PR TITLE
Refactor header and make playwright header tests work again

### DIFF
--- a/src/lib/Header.svelte
+++ b/src/lib/Header.svelte
@@ -20,7 +20,8 @@
 <header>
 	<div class="bg header">
 		<a href="/" class="logo-link" onclick={toggleNav}>
-			<img src="images/the_mighty_cow_white.svg" alt="The DDD South West cow" class="logo" />
+			<!-- For a11y purposes, the alt text on the image is the destination of the link - see https://www.w3.org/WAI/tutorials/images/functional/-->
+			<img src="images/the_mighty_cow_white.svg" alt="DDD South West home" class="logo" />
 		</a>
 		{#if isHomepage}
 			<div>

--- a/tests/page-object/header.ts
+++ b/tests/page-object/header.ts
@@ -12,7 +12,7 @@ export class Header {
 		this.navDropDownButton = page.getByRole('button', { name: 'Find out more' });
 		this.navMenu = page.getByRole('navigation').filter({ has: this.navDropDownButton });
 		this.navDropDown = this.navMenu.locator('.nav-link-container');
-		this.logo = page.getByRole('link', { name: 'The DDD South West logo' });
+		this.logo = page.getByAltText('DDD South West home');
 	}
 
 	getNavLinkTo(route: string): Locator {


### PR DESCRIPTION

- Refactor header to remove duplication (cherry picked from `nice-navbar` branch
- Make header logo link more accessible by setting the alt text on the image to the destination of the link (see https://www.w3.org/WAI/tutorials/images/functional/)
- Fix playwright logo link nav tests to use the new logo link selector (rather than a really old one)